### PR TITLE
Add barebones Task entity, repository, and controller

### DIFF
--- a/src/main/java/com/stride/controller/TaskController.java
+++ b/src/main/java/com/stride/controller/TaskController.java
@@ -1,0 +1,42 @@
+package com.stride.controller;
+
+import com.stride.model.Task;
+import com.stride.model.Project;
+import com.stride.repository.TaskRepository;
+import com.stride.repository.ProjectRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("api/tasks")
+public class TaskController {
+
+    private final TaskRepository taskRepository;
+    private final ProjectRepository projectRepository;
+
+    public TaskController(TaskRepository taskRepository, ProjectRepository projectRepository){
+        this.taskRepository = taskRepository;
+        this.projectRepository = projectRepository;
+
+    }
+
+    //Get all the tasks
+    @GetMapping
+    public List<Task> getAllTasks(){
+        return taskRepository.findAll();
+    }
+
+    //(Post) Add new tasks inside the project
+    public Task createTask(@RequestParam Long projectId, @RequestParam String title){
+        Project project = projectRepository.findById(projectId).orElseThrow(() -> new RuntimeException("Project not found"));
+
+
+        Task task = new Task(title, project);
+        return taskRepository.save(task);
+
+    }
+
+
+}

--- a/src/main/java/com/stride/model/Task.java
+++ b/src/main/java/com/stride/model/Task.java
@@ -1,0 +1,52 @@
+package com.stride.model;
+
+import jakarta.persistence.*; //Hibernate and JPA Annotation
+
+@Entity
+@Table(name = "tasks")
+
+public class Task {
+    @Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id; //Primary key
+
+    @Column(nullable = false) //Required field
+    private String title;
+
+    @ManyToOne //Many tasks can belong to one project
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+
+    //Necessary contructor
+    public Task(){}
+
+    //Convenience constructor
+    public Task(String title, Project project){
+        this.title = title;
+        this.project = project;
+    }
+
+    //Getters and Setters
+
+    public Long getId(){
+        return id;
+    }
+
+    public String getTitle(){
+        return title;
+    }
+
+    public void setTitle(String title){
+        this.title = title;
+    }
+
+    public Project getProject(){
+        return project;
+    }
+
+    public void setProject(Project project){
+        this.project = project;
+    }
+
+
+}

--- a/src/main/java/com/stride/repository/TaskRepository.java
+++ b/src/main/java/com/stride/repository/TaskRepository.java
@@ -1,0 +1,8 @@
+package com.stride.repository;
+
+import com.stride.model.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+}


### PR DESCRIPTION
Summary
Adds the initial Task entity and connects it with Projects.


Added `Task.java` (minimal entity with id, title, Project relation)
Added `TaskRepository.java`
Added `TaskController.java` with basic GET and POST endpoints

First step in extending Stride's backend from Users → Projects → Tasks.
Future PRs will add fields like `dueDate`, `priority`, and `status`.


Verified API with Postman:
  POST `/api/tasks?projectId=1&title=First Task`
  GET `/api/tasks` returns task list with Project reference